### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A fully compatible [MCP (Model Context Protocol)](https://github.com/mcp-protocol/spec) server for Desk3 crypto data, supporting Dify, Claude, Notion MCP, and other clients.
 
+<a href="https://glama.ai/mcp/servers/@desk3/cryptocurrency-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@desk3/cryptocurrency-mcp-server/badge" alt="Desk3 Server MCP server" />
+</a>
+
 ## Key Features
 
 - Implements all Desk3 crypto data endpoints as MCP resources and tools
@@ -110,5 +114,3 @@ This mode is only needed if you want to use MCP over stdin/stdout (not recommend
 - Make sure `uv` is installed and in your PATH.
 - Ensure your `DESK3_API_KEY` is valid.
 - If using Docker, set the API key with `-e DESK3_API_KEY=...`.
-
-


### PR DESCRIPTION
This PR adds a badge for the [Desk3 MCP Server](https://glama.ai/mcp/servers/@desk3/cryptocurrency-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@desk3/cryptocurrency-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@desk3/cryptocurrency-mcp-server/badge" alt="Desk3 Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.